### PR TITLE
fix: change EXPOSE port in Dockerfile to reflect cosanet's default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,6 @@ WORKDIR /app
 
 COPY --from=builder /app/cosanet .
 
-EXPOSE 9100
+EXPOSE 9156
 
 CMD ["/app/cosanet"]


### PR DESCRIPTION
Signed-off-by: Damien Degois <damien@degois.info>
